### PR TITLE
Make texture analysis compute textures

### DIFF
--- a/stereo-texture-analysis/README.md
+++ b/stereo-texture-analysis/README.md
@@ -99,17 +99,6 @@ For example on ubuntu do
 sudo apt-get install imagemagick r-base r-baes-core
 ```
 
-To install bayer2rgb follow the installation instructions in the corresponding README file
-
-```sh
-git clone git@github.com:jdthomas/bayer2rgb
-cd bayer2rgb
-make
-sudo cp bayer2rgb /usr/bin/
-mkdir ~/.magick
-cp delegates.xml ~/.magick/delegates.xml
-```
-
 For all the R libraries use the following:
 
 ```r
@@ -123,31 +112,36 @@ biocLite("EBImage")
 
 ### Running the tests
 
-- check that bayer2rgb works
+check that bayer2rgb works
 
-    bayer2rgb  -t -i gift-test.bin"$@" -o gift-test.tif -v  2472 -w 3296 -b 8 -m AHD -f GRBG
-
-- check that tif to png works with imagemagick's convert tool
-
-    convert gift-test.tif gift-test.png  ### some warning messages may pop up.--> convert.im6: gift-test.tif: Can not read TIFF directory count. `TIFFFetchDirectory' @ error/tiff.c/TIFFErrors/508. convert.im6: Failed to read directory at offset 488513821. `TIFFReadDirectory' @ error/tiff.c/TIFFErrors/508.
+```sh
+bayer2rgb  -t -i gift-test.bin"$@" -o gift-test.tif -v  2472 -w 3296 -b 8 -m AHD -f GRBG
+```
 
 
-- check that gift.R works
+check that tif to png works with imagemagick's convert tool
 
-    Rscript gift.R -h
+```sh
+convert gift-test.tif gift-test.png  ### some warning messages may pop up
+```
 
-    Rscript gift.R -f gift-test.png -t ### should return a tmp-table.csv file --> Error in cbind_all(x) : cannot convert object to a data frame Calls: %>% ... <Anonymous> -> cbind -> cbind -> bind_cols -> cbind_all -> .Call Execution halted
+check that gift.R works
 
-    Rscript gift.R -f gift-test.png -t -d -e -l ### should return all output files --> Error in cbind_all(x) : cannot convert object to a data frame Calls: %>% ... <Anonymous> -> cbind -> cbind -> bind_cols -> cbind_all -> .Call Execution halted
+```sh
+Rscript gift.R -h
 
+Rscript gift.R -f gift-test.png -t ### should return a tmp-table.csv file
 
+Rscript gift.R -f gift-test.png -t -d -e -l ### should return all output files
 
-    Rscript gift.R -f gift-test.png -t -r roi.png ### this analysis the image using a b/w image as ROI mask
+Rscript gift.R -f gift-test.png -t -r roi.png ### this analysis the image using a b/w image as ROI mask
+```
 
-- finally check that gift.sh works
+finally check that gift.sh works
 
-    ./gift.sh  gift-test.bin
-
+```sh
+./gift.sh  gift-test.tiff
+```
 
 ## Authors
 

--- a/stereo-texture-analysis/gift.R
+++ b/stereo-texture-analysis/gift.R
@@ -36,7 +36,6 @@ option_list <- list(
               type = "character",
               default = NULL,
               help = "The region of interest image file (white indicates ROI)"),
-
   make_option(c("-t", "--table"),
               type = "logical",
               action = "store_true",
@@ -129,11 +128,14 @@ df <- data.frame(d = as.vector(dgci),
   ungroup %>%
   group_by(roi, area, edges) %>%
   do({h = hist(.$d, breaks = seq(-0.1, 3, 0.1), plot = FALSE);
-      data.frame(breaks=paste0("dgci.",h$breaks[-length(h$breaks)]), counts=h$counts)}) %>%
-  tidyr::spread(breaks, counts) %>% as.data.frame df %>%
-  cbind(computeFeatures.moment(roi), computeFeatures.shape(roi))
+      data.frame(breaks = paste0("dgci.",h$breaks[-length(h$breaks)]), counts = h$counts)}) %>%
+  tidyr::spread(breaks, counts) %>% as.data.frame %>%
+  cbind(dgci = mean(dgci), computeFeatures.haralick(roi, dgci, scales = 1))
 
-
+# not using computeFeatures.moment(roi), computeFeatures.shape(roi)  
+# because these are only relevant if there are roi for different shapes
+# could be useful on individual plants at plot level prior to canopy closure
+# see https://github.com/terraref/reference-data/issues/172
 
 ### 6. Write features as table output
 ### 7. Write image output to directory


### PR DESCRIPTION
Following discussion in https://github.com/terraref/reference-data/issues/172

* removed computation of moments and shape properties that have no meaning without ROIs defined
* added computation of dgci mean and sd
* compute vector of Haralick texture metrics from 
[haralick1973tfi.pdf](https://github.com/terraref/extractors-stereo-rgb/files/1325461/haralick1973tfi.pdf) using EBImage package 

Question: There is a an option to compute multiple 'scales' of Haralick metrics. The default is to compute scales 1 and 2, but can apparently be any integer vector. I've hard-coded this to compute only scale 1. What is a scale in this context, and is 1 the appropriate scale to compute by default? (this ? cross posted in https://github.com/aoles/EBImage/issues/24)

(_note:_ reverts terraref/extractors-stereo-rgb#14 that reverted terraref/extractors-stereo-rgb#13, which was prematurely merged)