### PR TITLE
Reduced field mosaic thumbnail size

### DIFF
--- a/fieldmosaic/terra_fieldmosaic.py
+++ b/fieldmosaic/terra_fieldmosaic.py
@@ -133,7 +133,7 @@ class FullFieldMosaicStitcher(TerrarefExtractor):
             logging.info("Converting VRT to %s..." % out_tif_thumb)
 
             cmd = "gdal_translate -projwin -111.9750963 33.0764953 -111.9747967 33.074485715 " + \
-                    "-outsize 10%% 10%% %s %s" % (out_vrt, out_tif_thumb)
+                    "-outsize 2%% 2%% %s %s" % (out_vrt, out_tif_thumb)
             subprocess.call(cmd, shell=True)
             created += 1
             bytes += os.path.getsize(out_tif_thumb)


### PR DESCRIPTION
Changed from `--outsize 10% 10%` to `--outsize 2% 2%`

10% x 10% = 1% of total currently the fullfield RGB is 1.6 GB which defeats the purpose of a thumbnail.
I expect 2% x 2% --> 0.04% of total will reduce this 25 x to approx. 64MB. Hopefully this will be sufficiently small for a web-app (if not we can downscale on demand w/ imagemagick ... at least these will be manageable)