### PR TITLE
updated method name to match records in BETYdb

### DIFF
--- a/canopycover/terra_canopycover.py
+++ b/canopycover/terra_canopycover.py
@@ -29,7 +29,7 @@ def get_traits_table():
               'citation_author': '"Zongyang, Li"',
               'citation_year': '2016',
               'citation_title': 'Maricopa Field Station Data and Metadata',
-              'method': 'Canopy Cover Estimation from Field Scanner RGB images'}
+              'method': 'Green Canopy Cover Estimation from Field Scanner RGB images'}
 
     return (fields, traits)
 


### PR DESCRIPTION
Method Name in BETYdb is "Green Canopy Cover Estimation from Field Scanner RGB images" 

Per https://github.com/terraref/reference-data/issues/283#issuecomment-595965985